### PR TITLE
Add 20.04 to the FIPS kernel list

### DIFF
--- a/templates/kernel/variants.html
+++ b/templates/kernel/variants.html
@@ -148,8 +148,8 @@
       <h2 id="additional-kernel-variants">Additional kernel variants</h2>
       <p>In addition to those kernel variants, Canonical offers FIPS certified kernels:</p>
       <ul>
-        <li>FIPS &mdash; Certified GA kernel for Ubuntu 16.04 and 18.04</li>
-        <li>FIPS &mdash; compliant GA kernel with critical security and patch updates for Ubuntu 16.04 and 18.04</li>
+        <li>FIPS &mdash; Certified GA kernel for Ubuntu 16.04, 18.04, and 20.04</li>
+        <li>FIPS &mdash; compliant GA kernel with critical security and patch updates for Ubuntu 16.04, 18.04, and 20.04</li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Ubuntu also supports FIPS on 20.04 which I believe would mean it has it's own kernel variant.

## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
